### PR TITLE
gdb python bindings with python 3.13

### DIFF
--- a/gdb/python/py-gdb-readline.c
+++ b/gdb/python/py-gdb-readline.c
@@ -56,13 +56,11 @@ gdbpy_readline_wrapper (FILE *sys_stdin, FILE *sys_stdout,
       if (except.reason == RETURN_QUIT)
 	return NULL;
 
-      /* The thread state is nulled during gdbpy_readline_wrapper,
-	 with the original value saved in the following undocumented
-	 variable (see Python's Parser/myreadline.c and
-	 Modules/readline.c).  */
-      PyEval_RestoreThread (_PyOS_ReadlineTState);
+
+      /* This readline callback is called without the GIL held.  */
+      gdbpy_gil gil;
+
       gdbpy_convert_exception (except);
-      PyEval_SaveThread ();
       return NULL;
     }
 

--- a/gdb/python/python-internal.h
+++ b/gdb/python/python-internal.h
@@ -754,6 +754,30 @@ private:
   PyThreadState *m_save;
 };
 
+/* A helper class to save and restore the GIL, but without touching
+   the other globals that are handled by gdbpy_enter.  */
+
+class gdbpy_gil
+{
+public:
+
+  gdbpy_gil ()
+    : m_state (PyGILState_Ensure ())
+  {
+  }
+
+  ~gdbpy_gil ()
+  {
+    PyGILState_Release (m_state);
+  }
+
+  DISABLE_COPY_AND_ASSIGN (gdbpy_gil);
+
+private:
+
+  PyGILState_STATE m_state;
+};
+
 /* Use this after a TRY_EXCEPT to throw the appropriate Python
    exception.  */
 #define GDB_PY_HANDLE_EXCEPTION(Exception)	\

--- a/gdb/python/python.c
+++ b/gdb/python/python.c
@@ -257,30 +257,6 @@ gdbpy_enter::finalize ()
   python_gdbarch = target_gdbarch ();
 }
 
-/* A helper class to save and restore the GIL, but without touching
-   the other globals that are handled by gdbpy_enter.  */
-
-class gdbpy_gil
-{
-public:
-
-  gdbpy_gil ()
-    : m_state (PyGILState_Ensure ())
-  {
-  }
-
-  ~gdbpy_gil ()
-  {
-    PyGILState_Release (m_state);
-  }
-
-  DISABLE_COPY_AND_ASSIGN (gdbpy_gil);
-
-private:
-
-  PyGILState_STATE m_state;
-};
-
 /* Set the quit flag.  */
 
 static void


### PR DESCRIPTION
This fixes building the gdb python bindings with python 3.13.